### PR TITLE
fix: key callbacks and widget style normalization

### DIFF
--- a/src/trellis/platforms/common/client/src/core/htmlProps.ts
+++ b/src/trellis/platforms/common/client/src/core/htmlProps.ts
@@ -77,7 +77,8 @@ function normalizeInlineStyle(value: unknown): unknown {
 export function applyCompiledStyleProps(
   props: Record<string, unknown>
 ): Record<string, unknown> {
-  return props;
+  if (!("style" in props)) return props;
+  return { ...props, style: normalizeInlineStyle(props.style) };
 }
 
 export function toReactDomProps(props: Record<string, unknown>): Record<string, unknown> {

--- a/src/trellis/platforms/common/handler.py
+++ b/src/trellis/platforms/common/handler.py
@@ -515,13 +515,27 @@ class MessageHandler:
         handler_args = args[1:]
         processed_args, kwargs = _process_callback_args(handler_args)
 
+        # Only pass event args if the handler accepts them — most key handlers
+        # take zero args and would TypeError if given the keyboard event.
+        try:
+            sig = inspect.signature(callback)
+            accepts_args = any(
+                p.kind in (p.POSITIONAL_ONLY, p.POSITIONAL_OR_KEYWORD, p.VAR_POSITIONAL)
+                for p in sig.parameters.values()
+            )
+        except (ValueError, TypeError):
+            accepts_args = True
+
+        call_args = processed_args if accepts_args else []
+        call_kwargs = kwargs if accepts_args else {}
+
         handled = True
         try:
             with callback_context(session, element_id):
                 if inspect.iscoroutinefunction(callback):
-                    result = await callback(*processed_args, **kwargs)
+                    result = await callback(*call_args, **call_kwargs)
                 else:
-                    result = callback(*processed_args, **kwargs)
+                    result = callback(*call_args, **call_kwargs)
             # None or True = handled, False = pass
             if result is False:
                 handled = False


### PR DESCRIPTION
## Summary
- Key event callbacks now introspect handler signature before passing args, so zero-arg handlers (the common case) don't TypeError
- `applyCompiledStyleProps` normalizes kebab-case CSS names to camelCase for React, fixing broken styles on widget components (Button, Row, Column, etc.)

## Test plan
- [x] CI passes (Python + JS tests)
- [x] Widget showcase renders without CSS warnings in console
- [x] Key bindings fire without TypeError in keyboard section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed inline style processing to normalize styles consistently.
  * Improved event callback compatibility to support callbacks with optional arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->